### PR TITLE
Add rand state saving. Add _save_last_model.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -38,6 +38,8 @@ class Settings(BaseSettings):
     # CE for cross-entropy and MSE for mean-square-error
     criterion: str = "CE"
 
+    save_rand_state: bool = True
+
     @validator("criterion")
     def criterion_must_be_correct(cls, v):
         if v == "CE":

--- a/src/trainer/adv_trainer.py
+++ b/src/trainer/adv_trainer.py
@@ -71,6 +71,7 @@ class BaseADVTrainer(BaseTrainer):
         logger.info("finished training")
         logger.info(f"best robustness on test set: {best_robustness}")
 
+        self._save_last_model(f"{save_path}-last") # imTyrant added it for saving last model.
 
 class ADVTrainer(BaseADVTrainer):
     def __init__(self, model: SupportedAllModuleType, train_loader: DataLoader,

--- a/src/trainer/base_trainer.py
+++ b/src/trainer/base_trainer.py
@@ -226,4 +226,4 @@ class BaseTrainer:
 
             RandStateSnapshooter.lazy_set(f"{self._checkpoint_path}.rand")
             # imTyrant: High logging level is for notification.
-            logger.warning("loaded random state from '{self._checkpoint_path}.rand'")
+            logger.warning(f"loaded random state from '{self._checkpoint_path}.rand'")

--- a/src/trainer/robust_plus_regularization_trainer/robust_plus_singular_regularization_trainer.py
+++ b/src/trainer/robust_plus_regularization_trainer/robust_plus_singular_regularization_trainer.py
@@ -124,6 +124,8 @@ class RobustPlusSingularRegularizationTrainer(ADVTrainer, InitializeTensorboardM
         logger.info("finished training")
         logger.info(f"best robustness on test set: {best_robustness}")
 
+        self._save_last_model(f"{save_path}-last") # imTyrant added it for saving last model.
+
     def _register_forward_hook_to_k_block(self, k):
         total_blocks = self._blocks.get_total_blocks()
         assert 1 <= k <= total_blocks

--- a/src/trainer/transfer_learning_trainer/lwf_tl_trainer.py
+++ b/src/trainer/transfer_learning_trainer/lwf_tl_trainer.py
@@ -225,6 +225,13 @@ class LWFTransferLearningTrainer(ReshapeTeacherFCLayerMixin, ResetBlockMixin,
             "best_acc": best_acc
         }, f"{self._checkpoint_path}")
 
+        # Added by imTyrant
+        # For saving 'numpy' and 'torch' random state.
+        if hasattr(settings, "save_rand_state") and settings.save_rand_state:
+            from src.utils import RandStateSnapshooter
+            RandStateSnapshooter.lazy_take(f"{self._checkpoint_path}.rand")
+            logger.debug(f"random state is saved to '{self._checkpoint_path}.rand'")
+
     def _save_best_model(self, save_path, current_epochs, accuracy):
         """save best model with current info"""
         info = {
@@ -247,6 +254,20 @@ class LWFTransferLearningTrainer(ReshapeTeacherFCLayerMixin, ResetBlockMixin,
 
         self.start_epoch = start_epoch
         self.best_acc = best_acc
+
+        # Added by imTyrant
+        # For loading and setting random state.
+        if hasattr(settings, "save_rand_state") and settings.save_rand_state:
+            from src.utils import RandStateSnapshooter
+            
+            if not os.path.exists(f"{self._checkpoint_path}.rand"):
+                # Since no deterministically resuming is not consierred, previously, 
+                # '.rand' file may not exist.
+                return
+
+            RandStateSnapshooter.lazy_set(f"{self._checkpoint_path}.rand")
+            # imTyrant: High logging level is for notification.
+            logger.warning("loaded random state from '{self._checkpoint_path}.rand'")
 
     def _init_hyperparameters(self):
         self._lr = _LEARNING_RATE

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -15,3 +15,5 @@ from .data_utils import (
 )
 
 from .logging_utils import logger
+
+from .rand_state_snapshot import RandStateSnapshooter

--- a/src/utils/rand_state_snapshot.py
+++ b/src/utils/rand_state_snapshot.py
@@ -1,0 +1,90 @@
+from typing import Optional, Union, List, Dict
+import torch
+import numpy as np
+import copy
+
+
+"""
+    Here are stuffs for supporting deterministic experiments. Including getting 
+    and setting random states from/for 'numpy', 'torch', 'torch.cuda', etc.
+"""
+## GETTING RNG STATE ##
+def snapshotting_numpy_rand_state():
+    return copy.deepcopy(np.random.get_state())
+
+def snapshotting_torch_rand_state()->np.ndarray:
+    bt = copy.deepcopy(torch.random.get_rng_state()) #type:torch.ByteTensor
+    return bt.numpy()
+
+def snapshotting_cuda_rand_state(device:Optional[Union[torch.device, str]]="cuda")->np.ndarray:
+    if not torch.cuda.is_available():
+        return np.array([])
+    if isinstance(device, str):
+        device = torch.device(device)
+    bt = copy.deepcopy(torch.cuda.get_rng_state(device)) #type:torch.ByteTensor
+    return bt.numpy()
+
+def snapshotting_all_cuda_rand_state()->List[np.ndarray]:
+    if not torch.cuda.is_available():
+        return []
+    bts = torch.cuda.get_rng_state_all() #type:List[torch.ByteTensor]
+    return [copy.deepcopy(bt).numpy() for bt in bts]
+
+
+## SETTING RNG STATE ##
+def set_numpy_rand_state(state):
+    np.random.set_state(state)
+
+def set_torch_rand_state(state:np.ndarray):
+    torch.random.set_rng_state(torch.from_numpy(state))
+
+def set_cuda_rand_state(state:np.ndarray, device:Optional[Union[torch.device, str]]="cuda"):
+    if torch.cuda.is_available():
+        if isinstance(device, str):
+            device = torch.device(device)
+        torch.cuda.set_rng_state(torch.from_numpy(state), torch.device(device))
+
+# Use with caution. Manually setting states for all GPUs may mess up others' experiments.
+def set_all_cuda_rand_state(states:List[np.ndarray]):
+    if not torch.cuda.is_available():
+        return
+    if len(states) != torch.cuda.device_count():
+        raise ValueError("The number of given states should be equal to the number of GPUs")
+    torch.cuda.set_rng_state_all([torch.from_numpy(st) for st in states])
+
+
+
+class RandStateSnapshooter(object):
+    @staticmethod
+    def lazy_take(path):
+        import pickle as pkl
+        with open(path, "wb") as f:
+            pkl.dump(RandStateSnapshooter.take_snapshot(), f)
+    
+    @staticmethod
+    def lazy_set(path):
+        import pickle as pkl
+        with open(path, "rb") as f:
+            states = pkl.load(f)
+        RandStateSnapshooter.set_rand_state(states)
+        
+    @staticmethod
+    def take_snapshot():
+        state = {
+            "numpy": snapshotting_numpy_rand_state(),
+            "torch": snapshotting_torch_rand_state(),
+            "cuda": snapshotting_cuda_rand_state()
+        }
+        return state
+
+    @staticmethod
+    def set_rand_state(state:Dict):
+        if "numpy" in state:
+            set_numpy_rand_state(state["numpy"])
+        
+        if "torch" in state:
+            set_torch_rand_state(state["torch"])
+        
+        if "cuda" in state:
+            set_cuda_rand_state(state["cuda"])
+    


### PR DESCRIPTION
2020.12.24 更新
- 之前代码没有加入保存`numpy` 和 `torch`的随机状态，现在我在`BaseTrainer`和`LWFTransferLearningTrainer`里面加上了saver和set，同时也在`src.utils`里面加上了相关的函数。但是我还没有在`settings`里面加上`save_rand_state`这个开关。

- 此外，之前保存模型用的 `self._save_model` 函数，这里我改成了 `self._save_last_model`，为了兼容我另外写的一个`Trainer`（还没有push）。这里的改动包括：
  - BaseTrainer
  - ADVTrainer
  - RobustPlusSingularRegularizationTrainer

2020.12.25 更新
- 修改了一下读取rand state 的时候，logger f-string的bug
- 增加了`config.py`里面的控制项
